### PR TITLE
Allow mounting volumes from other containers

### DIFF
--- a/dockorm/container.py
+++ b/dockorm/container.py
@@ -103,7 +103,9 @@ class Container(HasTraits):
         return {}
 
     volumes_readwrite = Dict()
+
     volumes_readonly = Dict()
+
     volumes_no_bind = List()
 
     @property

--- a/dockorm/container.py
+++ b/dockorm/container.py
@@ -104,8 +104,7 @@ class Container(HasTraits):
 
     volumes_readwrite = Dict()
     volumes_readonly = Dict()
-    volumes_no_bind = []
-    volumes_from = None
+    volumes_no_bind = List()
 
     @property
     def volume_mount_points(self):
@@ -193,7 +192,6 @@ class Container(HasTraits):
             port_bindings=self.port_bindings,
             network_mode=self.network_mode,
             extra_hosts=self.extra_hosts,
-            volumes_from=self.volumes_from,
             # TODO: Support all of these.
             lxc_conf=None,
             publish_all_ports=False,
@@ -201,6 +199,7 @@ class Container(HasTraits):
             privileged=False,
             dns=None,
             dns_search=None,
+            volumes_from=None,
             restart_policy=None,
             cap_add=None,
             cap_drop=None,

--- a/dockorm/container.py
+++ b/dockorm/container.py
@@ -103,8 +103,9 @@ class Container(HasTraits):
         return {}
 
     volumes_readwrite = Dict()
-
     volumes_readonly = Dict()
+    volumes_no_bind = []
+    volumes_from = None
 
     @property
     def volume_mount_points(self):
@@ -192,6 +193,7 @@ class Container(HasTraits):
             port_bindings=self.port_bindings,
             network_mode=self.network_mode,
             extra_hosts=self.extra_hosts,
+            volumes_from=self.volumes_from,
             # TODO: Support all of these.
             lxc_conf=None,
             publish_all_ports=False,
@@ -199,7 +201,6 @@ class Container(HasTraits):
             privileged=False,
             dns=None,
             dns_search=None,
-            volumes_from=None,
             restart_policy=None,
             cap_add=None,
             cap_drop=None,
@@ -268,7 +269,7 @@ class Container(HasTraits):
             self.full_imagename(tag),
             name=self.name,
             ports=self.open_container_ports,
-            volumes=self.volume_mount_points,
+            volumes=self.volume_mount_points + self.volumes_no_bind,
             detach=not attach,
             stdin_open=attach,
             tty=attach,

--- a/dockorm/container.py
+++ b/dockorm/container.py
@@ -120,6 +120,7 @@ class Container(HasTraits):
             chain(
                 itervalues(self.volumes_readwrite),
                 itervalues(self.volumes_readonly),
+                volumes_no_bind,
             )
         )
 
@@ -268,7 +269,7 @@ class Container(HasTraits):
             self.full_imagename(tag),
             name=self.name,
             ports=self.open_container_ports,
-            volumes=self.volume_mount_points + self.volumes_no_bind,
+            volumes=self.volume_mount_points,
             detach=not attach,
             stdin_open=attach,
             tty=attach,

--- a/dockorm/container.py
+++ b/dockorm/container.py
@@ -122,7 +122,7 @@ class Container(HasTraits):
             chain(
                 itervalues(self.volumes_readwrite),
                 itervalues(self.volumes_readonly),
-                volumes_no_bind,
+                self.volumes_no_bind,
             )
         )
 


### PR DESCRIPTION
Previously all volumes were mounted from disk. This functionality supports downloading and sharing pipeline data in research.